### PR TITLE
Fix: Add explicit type annotations to resolve TS7006 errors

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -66,7 +66,7 @@ ipcMain.on('print-direct', (event, imageDataUrl, printerName) => {
 
     const base64Data = imageDataUrl.replace(/^data:image\/png;base64,/, "");
 
-    fs.writeFile(imagePath, base64Data, 'base64', (err) => {
+    fs.writeFile(imagePath, base64Data, 'base64', (err: any) => {
         if (err) {
             console.error("Error saving temp print image:", err);
             return;
@@ -87,7 +87,7 @@ ipcMain.on('print-direct', (event, imageDataUrl, printerName) => {
                 </body>
             </html>`;
 
-        fs.writeFile(htmlPath, htmlContent, (writeErr) => {
+        fs.writeFile(htmlPath, htmlContent, (writeErr: any) => {
             if (writeErr) {
                 console.error("Error saving temp print html:", writeErr);
                 return;
@@ -101,15 +101,15 @@ ipcMain.on('print-direct', (event, imageDataUrl, printerName) => {
 
                         printWindow.close();
 
-                        fs.unlink(imagePath, (unlinkErr) => {
+                        fs.unlink(imagePath, (unlinkErr: any) => {
                             if (unlinkErr) console.error("Error deleting temp image file:", unlinkErr);
                         });
-                        fs.unlink(htmlPath, (unlinkErr) => {
+                        fs.unlink(htmlPath, (unlinkErr: any) => {
                             if (unlinkErr) console.error("Error deleting temp html file:", unlinkErr);
                         });
                     });
                 });
-            }).catch(loadErr => {
+            }).catch((loadErr: any) => {
                 console.error("Error loading temp print html:", loadErr);
             });
         });


### PR DESCRIPTION
This commit resolves the `TS7006: Parameter '...' implicitly has an 'any' type` errors that were causing the build of the Electron main process to fail.

The `tsconfig.json` for the main process is configured with `"strict": true`, which requires all function parameters to have explicit types. The error callbacks in the `fs` module functions were missing these types.

The fix involves adding an explicit `: any` type annotation to the error parameters in the callbacks for `fs.writeFile` and `fs.unlink` within `electron/main.ts`. This satisfies the TypeScript compiler's strictness requirements and allows the build to complete successfully.