### PR TITLE
fix: Switch Windows build target to NSIS

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "output": "release"
     },
     "win": {
-      "target": "squirrel"
+      "target": "nsis"
     },
     "mac": {
       "target": "dmg"


### PR DESCRIPTION
Changes the electron-builder target for Windows from `squirrel` to `nsis`. This resolves a build error where `squirrel.windows` requires an `iconUrl`, which is not available for this project. NSIS does not have this requirement and will produce a standard Windows setup executable.