### PR TITLE
feat: Implement data persistence

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -67,6 +67,30 @@ app.on('activate', () => {
   }
 });
 
+const dataFilePath = path.join(app.getPath('userData'), 'data.json');
+
+ipcMain.handle('load-data', async () => {
+  try {
+    if (fs.existsSync(dataFilePath)) {
+      const fileContent = await fs.promises.readFile(dataFilePath, 'utf-8');
+      log.info('Data loaded successfully from', dataFilePath);
+      return JSON.parse(fileContent);
+    }
+  } catch (error) {
+    log.error('Error loading data:', error);
+  }
+  log.info('No data file found, will use initial mock data.');
+  return null;
+});
+
+ipcMain.handle('save-data', async (event, data) => {
+  try {
+    await fs.promises.writeFile(dataFilePath, JSON.stringify(data, null, 2));
+  } catch (error) {
+    log.error('Error saving data:', error);
+  }
+});
+
 // IPC handler for getting printers
 ipcMain.handle('get-printers', async () => {
   if (!mainWindow) {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -6,6 +6,8 @@ contextBridge.exposeInMainWorld('electron', {
     ipcRenderer.send('print-direct', htmlContent, printerName);
   },
   getPrinters: () => ipcRenderer.invoke('get-printers'),
+  loadData: () => ipcRenderer.invoke('load-data'),
+  saveData: (data: any) => ipcRenderer.invoke('save-data', data),
 });
 
 // Forward console logs from renderer to main process for logging

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -1,0 +1,12 @@
+import type { AppDataState } from '../types';
+
+export const dataService = {
+  loadData: async (): Promise<AppDataState | null> => {
+    // The 'any' is unfortunate but necessary because the window object is extended by the preload script.
+    return (window as any).electron.loadData();
+  },
+
+  saveData: async (data: AppDataState): Promise<void> => {
+    return (window as any).electron.saveData(data);
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,3 +120,15 @@ export enum View {
   Settings = 'settings',
   CashRegister = 'cash_register'
 }
+
+export interface AppDataState {
+  products: Product[];
+  sales: Sale[];
+  clients: Client[];
+  suppliers: Supplier[];
+  purchases: Purchase[];
+  users: User[];
+  companyInfo: CompanyInfo;
+  smtpConfig: SmtpConfig;
+  printerConfig: PrinterConfig;
+}


### PR DESCRIPTION
Implements a data persistence layer to save the application state to a JSON file, resolving the issue of data being lost when the app is closed.

- Adds IPC handlers in `electron/main.ts` to handle loading and saving data from/to `data.json` in the app's user data directory.
- Exposes these handlers to the renderer process via `electron/preload.ts`.
- Creates a `dataService.ts` to provide a clean interface for the persistence functions.
- Refactors `App.tsx` to be the single source of truth for the application's state.
- `App.tsx` now loads data from the file on startup, falling back to mock data if no file exists.
- A debounced `useEffect` hook saves the entire application state to the file whenever any data changes, ensuring all user actions are persisted.