### PR TITLE
fix: Correct TypeScript error in IPC log handler

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,8 +9,12 @@ import isDev from 'electron-is-dev';
 log.transports.file.resolvePath = () => path.join(app.getPath('userData'), 'logs', 'main.log');
 
 // IPC listener for logs from renderer process
-ipcMain.on('log', (event, level, ...args) => {
-  log[level](...args);
+type LogLevel = 'info' | 'warn' | 'error';
+ipcMain.on('log', (event, level: LogLevel, ...args) => {
+  // Ensure the level is one of the expected types before calling
+  if (['info', 'warn', 'error'].includes(level)) {
+    log[level](...args);
+  }
 });
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.


### PR DESCRIPTION
Fixes a TypeScript build error (TS7053) in `electron/main.ts`. The error was caused by dynamically indexing the `log` object with a variable of type `any`.

The fix introduces a `LogLevel` type and validates the `level` variable received over IPC before using it, ensuring type safety.