### PR TITLE
fix: Persist cash register state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,8 @@ const App: React.FC = () => {
         setCompanyInfo(loadedData.companyInfo);
         setSmtpConfig(loadedData.smtpConfig);
         setPrinterConfig(loadedData.printerConfig);
+        setActiveSession(loadedData.activeSession);
+        setCashTransactions(loadedData.cashTransactions);
         setCurrentUser(loadedData.users[0] || null); // Default to first user
       } else {
         // If no data file, initialize with mock data
@@ -95,7 +97,8 @@ const App: React.FC = () => {
     const handler = setTimeout(() => {
       const appData: AppDataState = {
         products, sales, clients, suppliers, purchases, users,
-        companyInfo, smtpConfig, printerConfig
+        companyInfo, smtpConfig, printerConfig,
+        activeSession, cashTransactions
       };
       dataService.saveData(appData);
       console.log("Data saved.");
@@ -104,7 +107,7 @@ const App: React.FC = () => {
     return () => {
       clearTimeout(handler);
     };
-  }, [products, sales, clients, suppliers, purchases, users, companyInfo, smtpConfig, printerConfig, isLoading]);
+  }, [products, sales, clients, suppliers, purchases, users, companyInfo, smtpConfig, printerConfig, activeSession, cashTransactions, isLoading]);
 
 
   // Lock/Unlock Handlers

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,4 +131,6 @@ export interface AppDataState {
   companyInfo: CompanyInfo;
   smtpConfig: SmtpConfig;
   printerConfig: PrinterConfig;
+  activeSession: CashRegisterSession | null;
+  cashTransactions: CashTransaction[];
 }


### PR DESCRIPTION
Updates the data persistence logic to include the cash register state (`activeSession` and `cashTransactions`).

This resolves an issue where the cash register data was not being saved when the application was closed. The `AppDataState` type has been updated, and the `App.tsx` component now correctly includes this state in the data that is saved to and loaded from the `data.json` file.