### PR TITLE
feat: Add security and robustness to cash register

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, shell, dialog } from 'electron';
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
@@ -44,13 +44,31 @@ const createWindow = () => {
     shell.openExternal(url);
     return { action: 'deny' };
   });
+
+  mainWindow.on('close', (event) => {
+    if (isCashRegisterOpen) {
+      event.preventDefault(); // Prevent the window from closing
+      dialog.showMessageBox(mainWindow!, {
+          type: 'warning',
+          title: 'Cierre de Caja Pendiente',
+          message: 'Debe cerrar la caja antes de salir de la aplicación.',
+          buttons: ['OK']
+      });
+    }
+  });
 };
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
+  let isCashRegisterOpen = false;
   // --- All setup that depends on the 'ready' event goes here ---
+
+  // IPC listener for cash register state
+  ipcMain.on('cash-register-state', (event, isOpen: boolean) => {
+    isCashRegisterOpen = isOpen;
+  });
 
   // 1. Configure logging and data paths
   const userDataPath = app.getPath('userData');

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld('electron', {
   getPrinters: () => ipcRenderer.invoke('get-printers'),
   loadData: () => ipcRenderer.invoke('load-data'),
   saveData: (data: any) => ipcRenderer.invoke('save-data', data),
+  notifyCashRegisterState: (isOpen: boolean) => ipcRenderer.send('cash-register-state', isOpen),
 });
 
 // Forward console logs from renderer to main process for logging

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ export interface Sale {
 
 export interface CashRegisterSession {
   id: string;
+  userId: string;
   startDate: string; // ISO string
   endDate: string | null;
   openingBalance: number;


### PR DESCRIPTION
Implements two new features based on user feedback to make the cash register more robust:
1.  **Access Control:** The Cash Register view is now restricted to 'admin' users only.
2.  **Forced Closure:** The application will now prevent the user from closing it if a cash register session is active, showing a dialog box to instruct the user to close the session first.

- `App.tsx` is updated with role-based access control for the Cash Register view.
- The `CashRegisterSession` type in `types.ts` now includes a `userId`.
- The `openCashRegister` function in `App.tsx` now stores the `userId`.
- A new IPC channel `cash-register-state` is used to communicate the open/closed status of the cash register from the renderer to the main process.
- `electron/main.ts` now listens for the window `close` event and prevents closing if the register is open.