### PR TITLE
fix: Correct variable scope for cash register state

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,6 +14,7 @@ if (require('electron-squirrel-startup')) {
 }
 
 let mainWindow: BrowserWindow | null;
+let isCashRegisterOpen = false;
 
 const createWindow = () => {
   log.info('Creating main window...');
@@ -62,7 +63,6 @@ const createWindow = () => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
-  let isCashRegisterOpen = false;
   // --- All setup that depends on the 'ready' event goes here ---
 
   // IPC listener for cash register state


### PR DESCRIPTION
Fixes a TypeScript build error (TS2304: Cannot find name 'isCashRegisterOpen') in `electron/main.ts`.

The error was caused by declaring the `isCashRegisterOpen` variable inside the `app.on('ready', ...)` callback, which made it inaccessible to the `mainWindow.on('close', ...)` event handler defined in the `createWindow` function.

This fix moves the `isCashRegisterOpen` declaration to the top-level module scope, making it accessible to all functions within the module and resolving the build error.