### PR TITLE
chore: Implement clean build process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "electron": "^29.3.0",
         "electron-builder": "^24.13.3",
         "postcss": "^8.4.38",
+        "rimraf": "^5.0.0",
         "tailwindcss": "^3.4.3",
         "typescript": "^5.2.2",
         "vite": "^5.2.0",
@@ -6272,6 +6273,22 @@
       "optional": true,
       "engines": {
         "node": ">= 0.8.15"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/roarr": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build:react": "vite build",
     "build:electron": "tsc -p tsconfig.node.json",
-    "build": "npm run build:react && npm run build:electron",
+    "clean": "rimraf dist dist-electron release",
+    "build": "npm run clean && npm run build:react && npm run build:electron",
     "dist": "npm run build && electron-builder",
     "electron:dev": "npm run build:electron && electron .",
     "start": "concurrently -k \"vite\" \"wait-on tcp:5173 && npm run electron:dev\""
@@ -43,6 +44,7 @@
     "recharts": "^2.12.7"
   },
   "devDependencies": {
+    "rimraf": "^5.0.0",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@vitejs/plugin-react": "^4.2.1",


### PR DESCRIPTION
Introduces a `clean` script to the build process to prevent issues with stale build artifacts.

- Adds `rimraf` as a dev dependency for cross-platform directory deletion.
- Creates a new `clean` script in `package.json` that removes the `dist`, `dist-electron`, and `release` directories.
- Updates the main `build` script to execute `npm run clean` before running the React and Electron build steps.

This ensures that every build is created from a fresh state, which should resolve issues where old or broken code was being incorrectly packaged into the final application.